### PR TITLE
Exclude repository configuration from release tarballs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# exclude repository and CI-configurations from the final tarballs
+.git*      	export-ignore
+.travis.yml	export-ignore
+.appveyor.yml   export-ignore


### PR DESCRIPTION
having .gitignore files in downstream VCS creates plenty of problems...